### PR TITLE
Delete Logs directory

### DIFF
--- a/Logs/shadercompiler-UnityShaderCompiler-0.log
+++ b/Logs/shadercompiler-UnityShaderCompiler-0.log
@@ -1,3 +1,0 @@
-Base path: '/Applications/Unity/Hub/Editor/6000.1.0f1/Unity.app/Contents', plugins path '/Applications/Unity/Hub/Editor/6000.1.0f1/Unity.app/Contents/PlaybackEngines'
-Cmd: initializeCompiler
-


### PR DESCRIPTION
Removes the Logs dir.

I updated the gitignore to ignore logs, I think this snuck into master before I realized it.  I read these are not all that useful even in debugging situations, so I think it should be fine to not track them with git.

[This](https://discussions.unity.com/t/should-i-add-log-files-to-gitignore/852937) is the forum thread I read to feel more confident in the decision.
